### PR TITLE
FEAT: SEC_04_05 입출금

### DIFF
--- a/securities/src/main/java/com/baas/securities/controller/AccountController.java
+++ b/securities/src/main/java/com/baas/securities/controller/AccountController.java
@@ -1,10 +1,7 @@
 package com.baas.securities.controller;
 
 import com.baas.securities.dto.ResponseDTO;
-import com.baas.securities.dto.account.CreateAccountReqDTO;
-import com.baas.securities.dto.account.CreateAccountResDTO;
-import com.baas.securities.dto.account.FindAccountReqDTO;
-import com.baas.securities.dto.account.FindAllAccountResDTO;
+import com.baas.securities.dto.account.*;
 import com.baas.securities.dto.agreement.UserAgreementReqDTO;
 import com.baas.securities.dto.agreement.UserAgreementResDTO;
 import com.baas.securities.dto.security.AuthUser;
@@ -66,5 +63,37 @@ public class AccountController {
         log.info("user={}, accounts={}", user.getEmail(), resDTO.getAccounts().size());
 
         return new ResponseDTO(HttpStatus.OK, "조회 성공", resDTO);
+    }
+
+    /**
+     * 3-4. 입금 / 출금
+     */
+
+    @PostMapping("/{accountId}/transaction")
+    public ResponseDTO processTransaction(
+            @Login AuthUser user,
+            @PathVariable String accountId,
+            @RequestBody TransactionReqDTO dto){
+        log.info("TRANSACTION user={}, accountId={}, type={}, amount={}", user.getEmail(), accountId, dto.getTransactionType(), dto.getAmount());
+        TransactionResDTO resDTO = accountService.processTransaction(user, accountId, dto);
+        return new ResponseDTO(HttpStatus.OK,"처리 완료",resDTO);
+    }
+
+    @PostMapping("/transfer")
+    public ResponseDTO transferFunds(@Login AuthUser user, @RequestBody TransferReqDTO dto) {
+        log.info("TRANSFER user={}, fromAcc={}, toAcc={}, amount={}",
+                user.getEmail(), dto.getFromAccountNumber(), dto.getToAccountNumber(), dto.getAmount());
+        try {
+            TransferResDTO resDTO = accountService.transfer(user, dto);
+            return new ResponseDTO(HttpStatus.OK, "송금이 완료되었습니다.", resDTO);
+        } catch (IllegalAccessException e) {
+            log.error("Transfer password error for user={}: {}", user.getEmail(), e.getMessage());
+            // 실제로는 ErrorCode 등을 포함한 표준 에러 응답 반환 필요
+            return new ResponseDTO(HttpStatus.BAD_REQUEST, "이체 비밀번호가 잘못되었습니다.", null);
+        } catch (IllegalArgumentException e) {
+            log.error("Transfer error for user={}: {}", user.getEmail(), e.getMessage());
+            // 실제로는 ErrorCode 등을 포함한 표준 에러 응답 반환 필요
+            return new ResponseDTO(HttpStatus.BAD_REQUEST, e.getMessage(), null);
+        }
     }
 }

--- a/securities/src/main/java/com/baas/securities/dto/account/TransactionReqDTO.java
+++ b/securities/src/main/java/com/baas/securities/dto/account/TransactionReqDTO.java
@@ -1,0 +1,18 @@
+package com.baas.securities.dto.account;
+
+import com.baas.securities.enums.TransactionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * 입출금 거래 요청용
+ */
+@Getter
+@NoArgsConstructor
+public class TransactionReqDTO {
+    private TransactionType transactionType;
+    private BigDecimal amount;
+}

--- a/securities/src/main/java/com/baas/securities/dto/account/TransactionResDTO.java
+++ b/securities/src/main/java/com/baas/securities/dto/account/TransactionResDTO.java
@@ -1,0 +1,15 @@
+package com.baas.securities.dto.account;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+/**
+ * 입출금 거래 응답용
+ */
+@Getter
+@AllArgsConstructor
+public class TransactionResDTO {
+    private String transactionId;
+    private BigDecimal updatedBalance;
+}

--- a/securities/src/main/java/com/baas/securities/dto/account/TransferReqDTO.java
+++ b/securities/src/main/java/com/baas/securities/dto/account/TransferReqDTO.java
@@ -1,0 +1,15 @@
+package com.baas.securities.dto.account;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+public class TransferReqDTO {
+    private String fromAccountNumber;
+    private String toAccountNumber;
+    private BigDecimal amount;
+    private String transferPassword;
+}

--- a/securities/src/main/java/com/baas/securities/dto/account/TransferResDTO.java
+++ b/securities/src/main/java/com/baas/securities/dto/account/TransferResDTO.java
@@ -1,0 +1,15 @@
+package com.baas.securities.dto.account;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class TransferResDTO {
+    private String fromAccountId;
+    private String toAccountId;
+    private BigDecimal transferredAmount;
+    private BigDecimal updatedFromBalance;
+}

--- a/securities/src/main/java/com/baas/securities/enums/TransactionType.java
+++ b/securities/src/main/java/com/baas/securities/enums/TransactionType.java
@@ -1,7 +1,8 @@
 package com.baas.securities.enums;
 
 public enum TransactionType {
-    BUY("매수"),SELL("매도"),SEND("송금"),DEPOSIT("입금");
+    //send 삭제 송금 개념은 각자 계좌 입장에서 입금이고 출금인거니까
+    BUY("매수"),SELL("매도"),DEPOSIT("입금"),WITHDRAW("출금");
 
     private String name;
 

--- a/securities/src/main/java/com/baas/securities/exception/ErrorResponse.java
+++ b/securities/src/main/java/com/baas/securities/exception/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.baas.securities.exception;
+
+import java.time.LocalDateTime;
+
+// 공통 에러 응답 객체
+public record ErrorResponse(
+        String code,       // 에러 코드 (ex: ACCOUNT-4001)
+        String message,    // 에러 메시지 (ex: "잔액이 부족합니다.")
+        LocalDateTime timestamp // 발생 시간
+) {
+    // 정적 팩토리 메서드 (생성 시점 자동 처리)
+    public static ErrorResponse of(String code, String message) {
+        return new ErrorResponse(code, message, LocalDateTime.now());
+    }
+}

--- a/securities/src/main/java/com/baas/securities/exception/GlobalExceptionHandler.java
+++ b/securities/src/main/java/com/baas/securities/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.baas.securities.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리 클래스
+ * 모든 예외를 JSON 형태로 처리
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    //  잔액 부족 예외 처리
+    @ExceptionHandler(InsufficientBalanceException.class)
+    public ResponseEntity<ErrorResponse> handleInsufficientBalance(InsufficientBalanceException e) {
+        ErrorResponse error = ErrorResponse.of("ACCOUNT-4001", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    // ️ 잘못된 요청(IllegalArgumentException 등)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
+        ErrorResponse error = ErrorResponse.of("COMMON-4000", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    //  예상치 못한 서버 내부 오류
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneral(Exception e) {
+        ErrorResponse error = ErrorResponse.of("SERVER-5000", "서버 내부 오류: " + e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+}

--- a/securities/src/main/java/com/baas/securities/exception/InsufficientBalanceException.java
+++ b/securities/src/main/java/com/baas/securities/exception/InsufficientBalanceException.java
@@ -1,0 +1,7 @@
+package com.baas.securities.exception;
+
+public class InsufficientBalanceException extends RuntimeException{
+    public InsufficientBalanceException(String message) {
+        super(message);
+    }
+}

--- a/securities/src/main/java/com/baas/securities/repository/AccountRepository.java
+++ b/securities/src/main/java/com/baas/securities/repository/AccountRepository.java
@@ -14,4 +14,5 @@ public interface AccountRepository {
     Optional<Account> findByAccountNumber(String accountNumber);
 
     List<Account> findAllByEmail(String email);
+    void update(Account account);
 }

--- a/securities/src/main/java/com/baas/securities/repository/dao/AccountDao.java
+++ b/securities/src/main/java/com/baas/securities/repository/dao/AccountDao.java
@@ -1,8 +1,10 @@
 package com.baas.securities.repository.dao;
 
 import com.baas.securities.repository.AccountRepository;
+import com.baas.securities.repository.entity.Account;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface AccountDao extends AccountRepository {
+    void update(Account account); // 잔액 업데이트
 }

--- a/securities/src/main/java/com/baas/securities/repository/dao/TransactionDao.java
+++ b/securities/src/main/java/com/baas/securities/repository/dao/TransactionDao.java
@@ -1,0 +1,10 @@
+package com.baas.securities.repository.dao;
+
+import com.baas.securities.repository.entity.Transaction;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface TransactionDao {
+    void insert(Transaction transaction);
+    Transaction findById(String id);
+}

--- a/securities/src/main/java/com/baas/securities/repository/impl/TransactionRepositoryImpl.java
+++ b/securities/src/main/java/com/baas/securities/repository/impl/TransactionRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.baas.securities.repository.impl;
 
 import com.baas.securities.repository.TransactionRepository;
+import com.baas.securities.repository.dao.TransactionDao;
 import com.baas.securities.repository.entity.Transaction;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Repository;
 
@@ -12,18 +14,20 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
 @Qualifier("TransactionRepository")
+@RequiredArgsConstructor
 public class TransactionRepositoryImpl implements TransactionRepository {
 
-    private final Map<String, Transaction> store = new ConcurrentHashMap<>();
-
+    //private final Map<String, Transaction> store = new ConcurrentHashMap<>();
+    private final TransactionDao transactionDao; // 5. DAO 주입받기
     @Override
     public Optional<Transaction> findById(String id) {
-        Transaction transaction = store.get(id);
-        return Optional.of(transaction);
+        return Optional.ofNullable(transactionDao.findById(id));
+
     }
 
     @Override
     public void save(Transaction transaction) {
-        store.put(transaction.getId(),transaction);
+
+        transactionDao.insert(transaction); // DB에 INSERT 실행
     }
 }

--- a/securities/src/main/java/com/baas/securities/service/AccountService.java
+++ b/securities/src/main/java/com/baas/securities/service/AccountService.java
@@ -2,18 +2,25 @@ package com.baas.securities.service;
 
 import com.baas.securities.dto.account.*;
 import com.baas.securities.dto.security.AuthUser;
+import com.baas.securities.enums.TransactionStatus;
+import com.baas.securities.enums.TransactionType;
+import com.baas.securities.exception.InsufficientBalanceException;
 import com.baas.securities.repository.AccountRepository;
+import com.baas.securities.repository.TransactionRepository;
 import com.baas.securities.repository.UserRepository;
 import com.baas.securities.repository.entity.Account;
+import com.baas.securities.repository.entity.Transaction;
 import com.baas.securities.repository.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.core.AbstractMessageSendingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -23,6 +30,160 @@ public class AccountService {
 
     private final AccountRepository accountRepository;
     private final UserRepository userRepository;
+    private final TransactionRepository transactionRepository;
+    private final AbstractMessageSendingTemplate abstractMessageSendingTemplate;
+
+
+    /**
+     *  송금 로직
+     */
+
+    @Transactional
+    public TransferResDTO transfer(AuthUser user, TransferReqDTO dto) throws IllegalAccessException {
+        // 1. 보내는 유저/ 계좌 확인
+        User findUser = userRepository.findByEmail(user.getEmail())
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        // todo : fromAccountNumber가 없으면 토큰 유저의 기본 계좌등을 찾는 로직 필요
+        // 요청이 있다고 가정
+        Account fromAccount = accountRepository.findByAccountNumber(dto.getFromAccountNumber())
+                .orElseThrow(() -> new IllegalArgumentException("보내는 계좌 정보를 찾을 수 없습니다."));
+
+        // 2. 본인 계좌 확인
+        isUserAccount(findUser, fromAccount);
+
+        // 3. 이체 비밀 번호 확인
+        validatePassword(fromAccount, dto.getTransferPassword());
+
+        // 4. 받는 계좌 확인
+        Account toAccount = accountRepository.findByAccountNumber(dto.getToAccountNumber())
+                .orElseThrow(() -> new IllegalArgumentException("받는 계좌 정보를 찾을 수 없습니다."));
+
+
+        // 5. 자기 자신에게 송금하는 경우 방지
+        if(fromAccount.getId().equals(toAccount.getId())){
+            throw new IllegalAccessException("자기 자신에게 송금할 수 없습니다.");
+        }
+
+        // 6. 잔액 확인
+        if (fromAccount.getBalance().compareTo(dto.getAmount()) < 0) {
+            throw new InsufficientBalanceException("출금 가능한 잔액이 부족합니다.");
+        }
+
+        // 7. 잔액 변경
+        fromAccount.updateBalance(fromAccount.getBalance().subtract(dto.getAmount()));
+        toAccount.updateBalance(toAccount.getBalance().add(dto.getAmount()));
+
+        // 8. 변경된 잔액 DB에 반영
+        accountRepository.update(fromAccount);
+        accountRepository.update(toAccount);
+
+        // 9. 거래 내역 기록 (출금, 입금 둘다)
+        saveTransferTransaction(fromAccount, toAccount, dto.getAmount());
+
+        log.info("송금 완료: {} -> {}, 금액: {}", fromAccount.getAccountNumber(), toAccount.getAccountNumber(), dto.getAmount());
+
+        // 10. 응답 DTO 반환
+        return new TransferResDTO(fromAccount.getId(), toAccount.getId(), dto.getAmount(), fromAccount.getBalance());
+
+    }
+
+    // 송금 거래 기록 저장 로직(출금.입금 트랜잭션 2개 생성)
+    private void saveTransferTransaction(Account fromAccount, Account toAccount, BigDecimal amount) {
+        // 출금 기록 (보내는 사람 기준)
+        Transaction withdrawal = Transaction.builder()
+                .accountId(fromAccount.getId())
+                .transactionType(TransactionType.WITHDRAW) // 출금 타입
+                .amount(amount.negate()) // 금액은 음수로 기록 (선택사항)
+                .status(TransactionStatus.SUCCESS)
+                .createdAt(LocalDateTime.now())
+                .completedAt(LocalDateTime.now())
+                .toAccountId(toAccount.getId()) // 상대방 계좌 ID 기록
+                // .toAccountType(toAccount.getAccountType()) // 필요하다면 타입도 기록
+                .build();
+        transactionRepository.save(withdrawal);
+
+        // 입금 기록 (받는 사람 기준)
+        Transaction deposit = Transaction.builder()
+                .accountId(toAccount.getId())
+                .transactionType(TransactionType.DEPOSIT) // 입금 타입
+                .amount(amount)
+                .status(TransactionStatus.SUCCESS)
+                .createdAt(LocalDateTime.now())
+                .completedAt(LocalDateTime.now())
+                // .fromAccountId(fromAccount.getId()) // 보낸 사람 ID 기록 (필요하다면)
+                .build();
+        transactionRepository.save(deposit);
+    }
+    /**
+     * 입출금 로직
+     */
+    public TransactionResDTO processTransaction(AuthUser user,String accountId, TransactionReqDTO dto) {
+        // 1. 유저 확인
+        User findUser = userRepository.findByEmail(user.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        // 2. 계좌 확인
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("계좌 정보를 찾을 수 없습니다."));
+
+        // 3. 본인 계좌 확인
+        isUserAccount(findUser, account);
+
+        // 4. 트랜잭션 타입에 따라 입급 또는 출금 처리
+        // todo : 증권 계좌는 단지 입금 혹은 송금만 있는것이니 논의 필요
+        switch (dto.getTransactionType()) {
+            case WITHDRAW :
+                withdraw(account, dto.getAmount());
+                break;
+            case DEPOSIT:
+                deposit(account,dto.getAmount());
+                break;
+            default :
+                throw new IllegalArgumentException("알 수 없는 트랜잭션 타입입니다");
+
+        }
+
+        // 5. 거래 내역 기록
+        saveTransaction(account,dto.getTransactionType(),dto.getAmount());
+
+        // 6. 응답 DTO 반환
+        return new TransactionResDTO(account.getId(), account.getBalance());
+
+    }
+
+
+    // 입금 로직
+    private void deposit(Account account, BigDecimal amount) {
+        account.updateBalance(account.getBalance().add(amount));
+        accountRepository.update(account);
+        log.info("입금 완료. 계좌 ID: {}, 현재 잔액: {}", account.getId(), account.getBalance());
+    }
+
+    // 출금 로직
+    private void withdraw(Account account, BigDecimal amount) {
+        // 출금 가능 잔액 부족 예외 처리
+        if (account.getBalance().compareTo(amount) < 0) {
+            throw new InsufficientBalanceException("출금 가능한 잔액이 부족합니다.");
+        }
+        account.updateBalance(account.getBalance().subtract(amount));
+        accountRepository.update(account);
+        log.info("출금 완료. 계좌 ID: {}, 현재 잔액: {}", account.getId(), account.getBalance());
+    }
+
+    // 거래 기록 저장 로직
+    private void saveTransaction(Account account, TransactionType type, BigDecimal amount) {
+        Transaction transaction = Transaction.builder()
+                .accountId(account.getId())
+                .transactionType(type)
+                .amount(amount)
+                .status(TransactionStatus.SUCCESS)
+                .createdAt(LocalDateTime.now())
+                .completedAt(LocalDateTime.now())
+                .build();
+
+        transactionRepository.save(transaction);
+    }
 
     public CreateAccountResDTO createAccount(AuthUser user, CreateAccountReqDTO dto) {
         // 1. 유저 확인.

--- a/securities/src/main/resources/mapper/AccountDaoMapper.xml
+++ b/securities/src/main/resources/mapper/AccountDaoMapper.xml
@@ -10,6 +10,14 @@
         values (#{id}, #{userId}, #{accountNumber}, #{accountPassword}, #{balance}, #{isActive}, #{accountType}, #{createdAt}, #{lastUpdate});
     </insert>
 
+    <update id="update" parameterType="com.baas.securities.repository.entity.Account">
+        UPDATE accounts
+        SET
+            balance = #{balance},
+            last_update = NOW() -- 현재 시간으로 업데이트
+        WHERE
+            id = #{id}
+    </update>
     <select id="findByAccountNumber" resultType="Account">
         select * from `accounts` where account_number = #{accountNumber};
     </select>

--- a/securities/src/main/resources/mapper/TransactionDaoMapper.xml
+++ b/securities/src/main/resources/mapper/TransactionDaoMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.baas.securities.repository.dao.TransactionDao">
+
+    <insert id="insert" parameterType="com.baas.securities.repository.entity.Transaction">
+        INSERT INTO transactions (
+            id, account_id, transaction_type, amount, status,
+            created_at, completed_at, order_id, fail_reason,
+            to_account_id, to_account_type
+        ) VALUES (
+                     #{id}, #{accountId}, #{transactionType}, #{amount}, #{status},
+                     #{createdAt}, #{completedAt}, #{orderId}, #{failReason},
+                     #{toAccountId}, #{toAccountType}
+                 )
+    </insert>
+
+</mapper>


### PR DESCRIPTION
입출금(+송금) 기능 구현
잔액 부족 에러처리 클래스 추가

## 📄 PR 한 줄 요약

계좌 입출금 및 송금(Transfer) 기능 구현 및 전역 잔액 부족 예외 처리 추가


## 🧑‍💻 PR 세부 내용


### 1. 기능 구현 및 API 엔드포인트 추가

#### 1-1. 입출금 API 기능 개선

* **엔드포인트**: `POST /api/accounts/{accountId}/transaction`
* **기능**: 특정 계좌에 대해 **입금(DEPOSIT)** 및 **출금(WITHDRAW)** 처리
* **처리 방식**:

  * 요청 바디를 통해 트랜잭션 유형과 금액을 전달받아 처리
  * 처리 결과를 거래 내역(Transaction)으로 저장

#### 1-2. 송금 API 신규 구현

* **엔드포인트**: `POST /api/accounts/transfer`
* **요청 DTO**: `TransferReqDTO`

  * 보내는 계좌 번호, 받는 계좌 번호, 금액, 비밀번호 포함
* **로직 요약**:

  * 송금 시 **출금 → 입금 순서**로 처리
  * `@Transactional` 적용으로 **원자성(Atomicity)** 보장
  * 거래 내역 테이블에 **출금 1건 + 입금 1건**으로 기록
  * `to_account_id` 컬럼을 통해 **상대방 정보**까지 정확히 기록

---

### 2. DB 반영 로직 개선

#### 2-1. 잔액(balance) 반영 로직 수정

* `AccountRepository` 및 `AccountDao`에 `update()` 메서드 추가
* `AccountDaoMapper.xml`에 `<update id="update">` 쿼리 정의
* `deposit`, `withdraw`, `transfer` 메서드에서 **모두 update 호출** 적용
* 잔액 변경과 함께 **`last_update` 필드**도 함께 갱신

#### 2-2. 거래 내역 영속성 확보

* 기존 메모리 기반 `TransactionRepositoryImpl` → **MyBatis 기반 DAO 구현체로 변경**
* 송금 시 거래 내역이 실제 DB에 저장되도록 수정
* `transactions` 테이블에 두 건의 기록(출금, 입금) 생성
* `to_account_id` 컬럼으로 **상대방 계좌 정보** 기록
* `order_id`의 `NOT NULL` 제약조건 관련 오류 해결

---

### 3. 전역 예외 처리 시스템 구축

#### 3-1. 예외 클래스 추가

* **`InsufficientBalanceException`** 클래스 신규 추가
* 출금 또는 송금 시 잔액 부족한 경우 명확히 처리

#### 3-2. GlobalExceptionHandler 처리

* `@RestControllerAdvice`로 전역 예외 핸들링 구성
* `InsufficientBalanceException` 발생 시:

  * HTTP 상태 코드: **400 Bad Request**
  * 응답 코드: `"ACCOUNT-4001"`
  * 메시지: 예외 메시지 본문에 그대로 반환
* `IllegalArgumentException`, `Exception` 등도 공통 처리

---




## 📎 Issue 번호
#6 
