### PR TITLE
FEAT / SEC-09 / Redis 마이그레이션 및 스케줄러 골격 구현

### DIFF
--- a/securities/build.gradle
+++ b/securities/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
 	// https://mvnrepository.com/artifact/io.github.cdimascio/dotenv-java
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/securities/src/main/java/com/baas/securities/config/RedisConfig.java
+++ b/securities/src/main/java/com/baas/securities/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.baas.securities.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+// 이 클래스가 설정 파일 임을 Spring에게 알려줌
+@Configuration
+public class RedisConfig {
+    // 메소드가 반환하는 객체를 스프링이 관리하는 빈으로 등록
+    // 이렇게 등록해두면 다른 클래스에서 @Autowired등으로 주입 받아 사용 가능
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        // key, value 모두 String으로 직렬화(Serializer) 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/securities/src/main/java/com/baas/securities/controller/RealTimeTradingController.java
+++ b/securities/src/main/java/com/baas/securities/controller/RealTimeTradingController.java
@@ -52,10 +52,11 @@ public class RealTimeTradingController {
      * 구독 컨트롤러
      * 구독 해지 로직은 ChanelInterceptor 에서 진행.
      */
-    @MessageMapping("/stock/{ticker}")
-    public void subRealtimeStockInfo(StompHeaderAccessor accessor, @DestinationVariable String ticker) throws IOException {
-        log.info("sub stomp: session id={}, ticker={}", accessor.getSessionId(), ticker);
-        String sessionId = accessor.getSessionId();
-        kisService.subRealtimeStock(sessionId, ticker);
-    }
+    // stomppreHandler가 이 역할 대신하며, race condition 유발할까봐 주석 처리
+//    @MessageMapping("/stock/{ticker}")
+//    public void subRealtimeStockInfo(StompHeaderAccessor accessor, @DestinationVariable String ticker) throws IOException {
+//        log.info("sub stomp: session id={}, ticker={}", accessor.getSessionId(), ticker);
+//        String sessionId = accessor.getSessionId();
+//        kisService.subRealtimeStock(sessionId, ticker);
+//    }
 }

--- a/securities/src/main/java/com/baas/securities/handler/StompPreHandler.java
+++ b/securities/src/main/java/com/baas/securities/handler/StompPreHandler.java
@@ -2,6 +2,7 @@ package com.baas.securities.handler;
 
 import com.baas.securities.enums.CustomStompCommand;
 import com.baas.securities.repository.KisSocketRepository;
+import com.baas.securities.service.KisService;
 import com.baas.securities.util.WebSocketMessageMaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,70 +13,128 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 
 import java.io.IOException;
 
-@Configuration
+@Component
 @Slf4j
 @RequiredArgsConstructor
 public class StompPreHandler implements ChannelInterceptor {
 
     private final KisSocketRepository kisRepository;
-    private final WebSocketMessageMaker messageMaker;
-
+    //private final WebSocketMessageMaker messageMaker;
+    private final KisService kisService;
     /**
      * 메시지 보내기 전에 요청을 가로채는 interceptor
-     * 실시간 주식 정보 수신 시에 stomp command가 DISCONNECT나 UNSUBSCRIBE 일때 종목에 대한 KIS 웹소켓 구독 해지
+     * 1. SUBSCRIBE: 첫 구독자일 경우 KIS 구독 메시지 전송
+     * 2. DISCONNECT/UNSUBSCRIBE: 마지막 구독자일 경우 KIS 구독 해지 메시지 전송
      */
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-
         String sessionId = accessor.getSessionId();
         StompCommand command = accessor.getCommand();
 
+        if (sessionId == null) {
+            log.warn("StompPreHandler: 세션 ID가 없는 요청입니다.");
+            return message;
+        }
+
         log.info("preSend: stomp session id={}, command={}", sessionId, command);
 
-        /**
-         * 구독이 끝났다면 repo에서 제거
-         * 종목에 대한 구독 끝 메시지 KIS에 전달.
-         */
-        if (isStompUnsubMsg(sessionId, command)) {
-            kisRepository.findTickerBySessionId(sessionId)
-                    .ifPresent(ticker -> {
-                        try {
-                            unsubscribeStock(ticker, sessionId);
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
-                    });
+        try {
+            // ---  5. (신규) SUBSCRIBE 로직 추가  ---
+            if (StompCommand.SUBSCRIBE.equals(command)) {
+                String destination = accessor.getDestination();
+                String ticker = parseStockCodeFromDestination(destination);
+
+                if (ticker != null) {
+                    log.info("[SUB] Session: {}, Ticker: {}", sessionId, ticker);
 
 
+                    // Redis에 구독자로 추가하고 '현재 총 인원수'를 받음
+                    int subscriberCount = kisRepository.subTicker(ticker, sessionId);
 
+                    // '첫 번째 구독자'라면 (방금 내가 추가해서 1명이 됨)
+                    if (subscriberCount == 1) {
+                        log.info("[KIS] 첫 구독자 발생. KIS에 구독 메시지 전송: {}", ticker);
+                        kisService.subscribeToStock(ticker);
+                    }
+                }
+            }
+            // ---  SUBSCRIBE 로직 끝  ---
+
+            // ---  6. (기존) DISCONNECT / UNSUBSCRIBE 로직  ---
+            else if (isStompUnsubMsg(sessionId, command)) {
+                kisRepository.findTickerBySessionId(sessionId)
+                        .ifPresent(ticker -> {
+                            try {
+                                log.info("[UNSUB/DIS] Session: {}, Ticker: {}", sessionId, ticker);
+                                unsubscribeStock(ticker, sessionId);
+                            } catch (IOException e) {
+                                log.error("구독 해지 처리 중 IO 예외 발생", e);
+                                // (필요시) throw new RuntimeException(e);
+                            }
+                        });
+            }
+        } catch (Exception e) {
+            // (예외 처리)
+            log.error("StompPreHandler 처리 중 예외 발생: {}", e.getMessage(), e);
         }
-        return ChannelInterceptor.super.preSend(message, channel);
+
+
+        return message;
     }
 
     private boolean isStompUnsubMsg(String sessionId, StompCommand command) {
+
         return kisRepository.isStompSessionId(sessionId) && command != null && CustomStompCommand.isCloseCommand(command.name());
     }
 
     private void unsubscribeStock(String ticker, String sessionId) throws IOException {
+
         int subscriber = kisRepository.unsubTicker(ticker, sessionId);
 
         if (subscriber > 0) {
+            log.info("[KIS] 구독자 {}명 남음 (해지 안함): {}", subscriber, ticker);
             return;
         }
+
         /**
          * 만약 종목 구독자가 0명이라면 KIS 에게 종목 구독 해지 메시지 송신.
          */
-        String approvalKey = kisRepository.getApprovalKey();
+        log.info("[KIS] 마지막 구독자 퇴장. KIS에 구독 해지 메시지 전송: {}", ticker);
+        // (KisService의 메소드 호출로 변경)
+        kisService.unsubscribeFromStock(ticker);
 
+        /* (KisService가 이 로직을 대신 수행함)
+        String approvalKey = kisRepository.getApprovalKey();
         String reqMsg = messageMaker.buildUnsubRequest(ticker, approvalKey);
         kisRepository.getKisSession()
                 .orElseThrow(() -> new IllegalArgumentException("웹소켓 세션을 찾지 못하였습니다."))
                 .sendMessage(new TextMessage(reqMsg));
         log.info("unsubscribe={}", ticker);
+        */
+    }
+
+    /**
+     * (신규) Destination 경로에서 종목 코드를 파싱합니다.
+     * (예: "/sub/stock/005930" -> "005930" 반환)
+     */
+    private String parseStockCodeFromDestination(String destination) {
+        if (destination == null || !destination.startsWith("/sub/stock/")) {
+            return null;
+        }
+        try {
+            String[] parts = destination.split("/");
+            if (parts.length > 0) {
+                return parts[parts.length - 1]; // 마지막 부분을 종목 코드로 간주
+            }
+        } catch (Exception e) {
+            log.error("Destination 파싱 실패: {}", destination, e);
+        }
+        return null;
     }
 }

--- a/securities/src/main/java/com/baas/securities/repository/KisSocketRepository.java
+++ b/securities/src/main/java/com/baas/securities/repository/KisSocketRepository.java
@@ -11,7 +11,7 @@ import java.util.Set;
  */
 
 public interface KisSocketRepository {
-    void subTicker(String ticker, String sessionId);
+    int subTicker(String ticker, String sessionId);
 
     boolean haveSubscriber(String ticker);
 
@@ -30,4 +30,6 @@ public interface KisSocketRepository {
     Set<String> getTickers();
 
     String getApprovalKey();
+
+    void updateApprovalKey(String newApprovalKey);
 }

--- a/securities/src/main/java/com/baas/securities/repository/impl/KisSocketRepositoryImpl.java
+++ b/securities/src/main/java/com/baas/securities/repository/impl/KisSocketRepositoryImpl.java
@@ -5,103 +5,198 @@ import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.util.Map;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 @Repository
 @Slf4j
 @Qualifier("KisSocketRepository")
 public class KisSocketRepositoryImpl implements KisSocketRepository {
 
-//    @Value("${KIS_WEBSOCKET_APPROVAL_KEY}")
+    //    @Value("${KIS_WEBSOCKET_APPROVAL_KEY}")
     private String approvalKey="faesfasdfasdf";
-    /**
-     * K : 세션 아이디 (스톰프 구독자 세션 아이디), V : 종목명 (Ticker)
-     */
-    private final Map<String, String> users = new ConcurrentHashMap<>();
-    /**
-     * K : 종목명 (Ticker), V : 세션 아이디 리스트 (스톰프 구독자 세션 아이디)
-     */
-    private final Map<String, CopyOnWriteArrayList<String>> store = new ConcurrentHashMap<>();
 
-    private final Map<String, Object> infos = new ConcurrentHashMap<>();
+    // ---  2. 기존 Map 변수들(users, store, infos) 삭제  ---
+    // private final Map<String, String> users = ... (삭제)
+    // private final Map<String, CopyOnWriteArrayList<String>> store = ... (삭제)
+    // private final Map<String, Object> infos = ... (삭제)
+
+    // ---  3. Redis 템플릿과 KIS 세션 변수 추가  ---
+
+    /**
+     * Redis를 사용하기 위한 핵심 도구 (String 특화)
+     */
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * KIS 실제 웹소켓 세션. (Redis에 저장 불가!)
+     * 이 객체는 이 서버 인스턴스의 메모리에만 존재해야 합니다.
+     * 'volatile' 키워드는 멀티 스레드 환경에서 변수 변경 사항을 즉시 반영합니다.
+     */
+    private volatile WebSocketSession kisSession = null;
+
+    /**
+     * Redis 키 접두사 (Key 관리용)
+     */
+    private static final String KEY_STORE_TICKER_PREFIX = "kis:store:ticker:"; // (종목별 세션 Set)
+    private static final String KEY_USERS_SESSION = "kis:users:session";       // (세션-종목 Hash)
+    private static final String KEY_INFOS_APPROVAL = "kis:infos:approvalKey";  // (승인 키 String)
+
+    /**
+     * 4. 생성자 주입
+     * Spring이 StringRedisTemplate Bean을 여기에 주입해 줍니다.
+     */
+    public KisSocketRepositoryImpl(StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
 
     @PostConstruct
     private void init() {
-        infos.put("approvalKey", approvalKey);
+        // infos.put("approvalKey", approvalKey); (삭제)
+
+        // 5. approvalKey를 Redis에 저장
+        updateApprovalKey(approvalKey);
     }
 
     @Override
-    public void subTicker(String ticker, String sessionId) {
-//        if (!store.containsKey(ticker)) {
-//            store.put(ticker, new CopyOnWriteArrayList<>());
-//        }
-//        store.get(ticker).add(sessionId);
-        /**
-         * 동시성 처리에 안전.
-         * 위 코드는 race condition이 발생할 수 있음.
-         */
-        store.computeIfAbsent(ticker, k -> new CopyOnWriteArrayList<>()).add(sessionId);
-        users.put(sessionId, ticker);
+    public int subTicker(String ticker, String sessionId) {
+        // store.computeIfAbsent(ticker, k -> new CopyOnWriteArrayList<>()).add(sessionId); (삭제)
+        // users.put(sessionId, ticker); (삭제)
+
+        // 6. Redis로 대체
+        // (store -> Set 자료구조) "어떤 Ticker에 어떤 세션들이 있는지"
+        stringRedisTemplate.opsForSet().add(KEY_STORE_TICKER_PREFIX + ticker, sessionId);
+
+        // (users -> Hash 자료구조) "어떤 세션이 어떤 Ticker를 보는지"
+        stringRedisTemplate.opsForHash().put(KEY_USERS_SESSION, sessionId, ticker);
+
         logging(ticker, sessionId);
+        // 현재 총 인워수 반환
+        Long count = stringRedisTemplate.opsForSet().size(KEY_STORE_TICKER_PREFIX + ticker);
+        return (count == null) ? 0 : count.intValue();
+
     }
 
     @Override
     public boolean haveSubscriber(String ticker) {
-        return store.containsKey(ticker) && !store.get(ticker).isEmpty();
+        // return store.containsKey(ticker) && !store.get(ticker).isEmpty(); (삭제)
+
+        // 7. Redis로 대체 (Set에 멤버가 있는지 확인)
+        Long count = stringRedisTemplate.opsForSet().size(KEY_STORE_TICKER_PREFIX + ticker);
+        return (count != null && count > 0);
     }
 
     @Override
     public int unsubTicker(String ticker, String sessionId) {
-        store.get(ticker).remove(sessionId);
-        users.remove(sessionId);
+        // store.get(ticker).remove(sessionId); (삭제)
+        // users.remove(sessionId); (삭제)
+
+        // 8. Redis로 대체
+        // (store -> Set에서 제거)
+        stringRedisTemplate.opsForSet().remove(KEY_STORE_TICKER_PREFIX + ticker, sessionId);
+        // (users -> Hash에서 제거)
+        stringRedisTemplate.opsForHash().delete(KEY_USERS_SESSION, sessionId);
+
         logging(ticker, sessionId);
-        return store.get(ticker).size();
+
+        Long count = stringRedisTemplate.opsForSet().size(KEY_STORE_TICKER_PREFIX + ticker);
+        return (count == null) ? 0 : count.intValue();
     }
 
     @Override
     public void setKisSession(WebSocketSession session) {
-        infos.put("session", session);
+        // infos.put("session", session); (삭제)
+
+        // 9. 로컬 변수에 저장 (Redis 아님!)
+        this.kisSession = session;
     }
 
     @Override
     public void removeKisSession(WebSocketSession session) {
-        infos.remove(session.getId());
+        // infos.remove(session.getId()); (삭제) (-> 로직 변경 필요)
+
+        // 10. 로컬 변수에서 제거 (및 세션 닫기)
+        if (this.kisSession != null && this.kisSession.getId().equals(session.getId())) {
+            try {
+                this.kisSession.close(); // 실제 세션 연결도 닫아줌
+            } catch (IOException e) {
+                log.warn("KIS 세션 닫기 실패: {}", e.getMessage());
+            }
+            this.kisSession = null;
+        }
     }
 
     @Override
     public Optional<WebSocketSession> getKisSession() {
-        return Optional.of((WebSocketSession) infos.getOrDefault("session", null));
+        // return Optional.of((WebSocketSession) infos.getOrDefault("session", null)); (삭제)
+
+        // 11. 로컬 변수에서 반환
+        return Optional.ofNullable(this.kisSession);
     }
 
     @Override
     public Optional<String> findTickerBySessionId(String sessionId) {
-        return Optional.of(users.getOrDefault(sessionId, null));
+        // return Optional.of(users.getOrDefault(sessionId, null)); (삭제)
+
+        // 12. Redis Hash에서 조회
+        Object ticker = stringRedisTemplate.opsForHash().get(KEY_USERS_SESSION, sessionId);
+        return Optional.ofNullable((String) ticker);
     }
 
     @Override
     public boolean isStompSessionId(String sessionId) {
-        return users.containsKey(sessionId);
+        // return users.containsKey(sessionId); (삭제)
+
+        // 13. Redis Hash에 키가 있는지 확인
+        return stringRedisTemplate.opsForHash().hasKey(KEY_USERS_SESSION, sessionId);
     }
 
     @Override
     public Set<String> getTickers() {
-        return store.keySet();
+        // return store.keySet(); (삭제)
+
+        // 14. Redis에서 "kis:store:ticker:"로 시작하는 모든 키를 찾음
+        Set<String> keys = stringRedisTemplate.keys(KEY_STORE_TICKER_PREFIX + "*");
+        if (keys == null) {
+            return Set.of(); // 빈 Set 반환
+        }
+
+        // "kis:store:ticker:005930" -> "005930" 으로 변환
+        int prefixLength = KEY_STORE_TICKER_PREFIX.length();
+        return keys.stream()
+                .map(key -> key.substring(prefixLength))
+                .collect(Collectors.toSet());
     }
 
     @Override
     public String getApprovalKey() {
-        return (String) infos.get("approvalKey");
+        // return (String) infos.get("approvalKey"); (삭제)
+
+        // 15. Redis에서 조회
+        return stringRedisTemplate.opsForValue().get(KEY_INFOS_APPROVAL);
+    }
+
+    /*
+     * 17. KIS Approval Key 갱신 메소드 구현
+     */
+    @Override
+    public void updateApprovalKey(String newApprovalKey) {
+        // 'init()' 메소드에서 사용한 것과 동일한 키에 새 값을 덮어씁니다.
+        stringRedisTemplate.opsForValue().set(KEY_INFOS_APPROVAL, newApprovalKey);
+        log.info("KIS Approval Key가 Redis에 갱신되었습니다. New Key (일부): {}",
+                newApprovalKey.substring(0, Math.min(newApprovalKey.length(), 10)) + "...");
     }
 
     private void logging(String ticker, String user) {
-        log.info("session id in {} = (size={}) {}", ticker, store.get(ticker).size(), store.get(ticker));
-        log.info("session id in {} = {}", ticker, store.get(ticker));
+        // 16. 로깅 로직도 Redis 기반으로 수정
+        Long size = stringRedisTemplate.opsForSet().size(KEY_STORE_TICKER_PREFIX + ticker);
+        Set<String> members = stringRedisTemplate.opsForSet().members(KEY_STORE_TICKER_PREFIX + ticker);
+        log.info("session id in {} = (size={}) {}", ticker, size, members);
     }
 }

--- a/securities/src/main/java/com/baas/securities/scheduler/KisScheduler.java
+++ b/securities/src/main/java/com/baas/securities/scheduler/KisScheduler.java
@@ -1,0 +1,47 @@
+package com.baas.securities.scheduler;
+
+import com.baas.securities.repository.KisSocketRepository;
+import com.baas.securities.service.KisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KisScheduler {
+
+    // KIS API를 호출하여 '새 키'를 받아오는 로직이 담긴 서비스
+    private final KisService kisService;
+
+    // 받아온 '새 키'를 Redis에 저장하는 레포지토리
+    private final KisSocketRepository kisSocketRepository;
+
+
+    @Scheduled(cron = "0 55 23 * * *", zone = "Asia/Seoul")
+    public void refreshKisApprovalKey() {
+        log.info("KIS 승인 키 갱신 스케줄러 시작 (매일 23:55)");
+
+        try {
+            // 1. KisService를 통해 KIS API를 호출해서 '새 승인 키'를 발급받습니다.
+            //    (이 메소드는 KisService에 새로 만들어야 합니다)
+            String newApprovalKey = kisService.fetchNewApprovalKeyFromKisApi();
+
+            if (newApprovalKey != null && !newApprovalKey.isEmpty()) {
+
+                // 2. KisSocketRepository를 통해 '새 승인 키'를 Redis에 덮어씁니다.
+                kisSocketRepository.updateApprovalKey(newApprovalKey);
+
+                log.info("KIS 승인 키 갱신 성공");
+
+            } else {
+                log.warn("KIS 승인 키 갱신 실패: KIS API로부터 유효한 키를 받지 못했습니다.");
+            }
+
+        } catch (Exception e) {
+            log.error("KIS 승인 키 갱신 중 심각한 오류 발생", e);
+        }
+    }
+}

--- a/securities/src/main/java/com/baas/securities/service/KisService.java
+++ b/securities/src/main/java/com/baas/securities/service/KisService.java
@@ -19,38 +19,63 @@ public class KisService {
     private final KisSocketRepository kisRepository;
     private final WebSocketMessageMaker messageMaker;
 
-    public void subRealtimeStock(String sessionId, String ticker) throws IOException {
-        /**
-         * 종목에 대한 구독이 없으면 KIS 서버에 구독 메시지 전송
-         */
-        log.info("ticker: {}, have subscriber={}", ticker, kisRepository.haveSubscriber(ticker));
+    /**
+     *
+     * KIS 서버에 실제 '구독' 메시지를 전송
+     * @param ticker 종목 코드
+     */
+    public void subscribeToStock(String ticker) throws IOException {
+        String approvalKey = kisRepository.getApprovalKey();
 
-        if (!kisRepository.haveSubscriber(ticker)) {
-            sendRequestMsg(ticker);
-        }
-        /**
-         * 종목에 대한 구독 세션 아이디 저장
-         */
-        kisRepository.subTicker(ticker, sessionId);
+        // (중요) messageMaker에 buildSubRequest가 있어야 합니다.
+        String reqMsg = messageMaker.buildSubRequest(ticker, approvalKey);
+
+        log.info("KIS 구독 메시지 전송: {}, {}", ticker, reqMsg);
+
+        kisRepository.getKisSession()
+                .orElseThrow(() -> new IllegalArgumentException("KIS 웹소켓이 연결되어있지 않습니다."))
+                .sendMessage(new TextMessage(reqMsg));
+
+        log.info("KIS 구독 요청 완료: {}", ticker);
     }
 
     /**
-     * unsubRealtimeStock(구독해지)은 Interceptor에서 Repository로 진행
+     * KIS 서버에 실제 '구독 해지' 메시지를 전송합니다.
+     * @param ticker 종목 코드
      */
-
-    private void sendRequestMsg(String ticker) throws IOException {
-        // TODO : Session Error Handling
+    public void unsubscribeFromStock(String ticker) throws IOException {
         String approvalKey = kisRepository.getApprovalKey();
-        String reqMsg = messageMaker.buildSubRequest(ticker, approvalKey);
 
-        log.info("sub msg to {}, {}", ticker, reqMsg);
+        // (중요) messageMaker에 '구독 해지' 메시지를 만드는 메소드가 필요합니다.
+        //       (이름은 예시입니다: buildUnsubRequest)
+        String reqMsg = messageMaker.buildUnsubRequest(ticker, approvalKey);
+
+        log.info("KIS 구독 해지 메시지 전송: {}, {}", ticker, reqMsg);
 
         kisRepository.getKisSession()
-                .orElseThrow(() -> new IllegalArgumentException("웹소켓이 연결되어있지 않습니다."))
+                .orElseThrow(() -> new IllegalArgumentException("KIS 웹소켓이 연결되어있지 않습니다."))
                 .sendMessage(new TextMessage(reqMsg));
 
-        log.info("subscribe to {}", ticker);
+        log.info("KIS 구독 해지 요청 완료: {}", ticker);
     }
 
+    /**
+     * [KisScheduler가 호출]
+     * KIS API를 직접 호출하여 새 Approval Key를 발급받아 반환합니다.
+     * @return 새로 발급받은 KIS 승인 키 (String)
+     * @throws Exception API 호출 실패 시
+     */
+    public String fetchNewApprovalKeyFromKisApi() throws Exception {
+        log.info("KIS API에 새 승인 키 발급을 요청합니다...");
+
+        // TODO: (이전 설명과 동일)
+        // KIS '승인 키 발급' API 실제 호출 로직 구현...
+        // (RestTemplate 또는 WebClient 사용)
+
+        // (임시 반환값) -> 위 TODO를 실제 로직으로 교체해야 함
+        String temporaryNewKey = "temp_new_key_from_api_call_" + System.currentTimeMillis();
+        log.info("임시 새 키 발급: {}", temporaryNewKey);
+        return temporaryNewKey;
+    }
 
 }

--- a/securities/src/main/resources/application.yml
+++ b/securities/src/main/resources/application.yml
@@ -21,6 +21,11 @@ spring:
           auth: true
           starttls:
             enable: true
+  ## 레디스 설정
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 
 mybatis:


### PR DESCRIPTION
StompPreHandler의 구독/해지 로직을 Redis 기반으로 수정하고, KIS 승인 키 갱신을 위한 스케줄러를 추가함.

## 📄 PR 한 줄 요약

실시간 시세 구독 로직의 Race Condition을 해결하고, Redis를 도입하여 구독자 및 KIS 세션을 중앙 관리하도록 변경

## 🧑‍💻 PR 세부 내용

신규 생성 파일 (3개)
1. securities/src/main/java/com/baas/securities/config/RedisConfig.java

@Configuration 설정 파일 추가.

@Bean 등록: RedisTemplate<String, Object>

역할: Spring Boot가 application.yml의 정보를 바탕으로 Redis에 연결하고, Java 객체를 JSON으로 직렬화(Serializer)하여 Redis와 통신할 수 있도록 RedisTemplate을 Bean으로 등록함.

2. securities/src/main/java/com/baas/securities/scheduler/KisScheduler.java

@Component 및 @RequiredArgsConstructor 사용.

@Scheduled(cron = "0 55 23 * * *", zone = "Asia/Seoul")을 사용하는 refreshKisApprovalKey 메소드 추가.

역할: 매일 23시 55분 KIS 승인 키(approvalKey) 만료에 대비하여, KisService를 호출해 새 키를 발급받고 KisSocketRepository를 통해 Redis에 갱신함.

3. securities/src/main/java/com/baas/securities/handler/StompPreHandler.java

@Component 및 @RequiredArgsConstructor 사용 (기존 @Configuration 대체).

ChannelInterceptor 구현체.

역할: STOMP 메시지(SUBSCRIBE, DISCONNECT, UNSUBSCRIBE)를 중앙에서 가로채(PreSend) 구독/해지 로직을 원자적으로(Atomic) 처리함.

수정된 로직:

SUBSCRIBE: kisRepository.subTicker()를 호출하고, 반환된 구독자 수(int)가 1일 경우 (첫 구독자) kisService.subscribeToStock()을 호출함.

UNSUBSCRIBE/DISCONNECT: 기존 unsubscribeStock() 로직과 결합하여, kisRepository.unsubTicker() 후 반환된 구독자 수(int)가 0일 경우 (마지막 구독자) kisService.unsubscribeFromStock()을 호출함.

수정된 파일 (6개)
1. build.gradle

dependencies에 implementation 'org.springframework.boot:spring-boot-starter-data-redis' 의존성 추가.

2. securities/src/main/java/com/baas/securities/SecuritiesApplication.java

@EnableScheduling 어노테이션 추가.

역할: @Scheduled 어노테이션(in KisScheduler)이 동작하도록 스케줄링 기능 활성화.

3. securities/src/main/java/com/baas/securities/repository/KisSocketRepository.java (인터페이스)

subTicker(String ticker, String sessionId): 메소드 반환 타입을 void에서 **int**로 변경.

updateApprovalKey(String newApprovalKey): void 타입 메소드 선언 추가.

4. securities/src/main/java/com/baas/securities/repository/impl/KisSocketRepositoryImpl.java (구현체)

(핵심) 기존 Map, CopyOnWriteArrayList 등 JVM 메모리 기반 저장을 StringRedisTemplate 기반의 Redis 저장으로 전면 교체.

store (종목-세션) -> Redis Set (opsForSet)

users (세션-종목) -> Redis Hash (opsForHash)

approvalKey (infos) -> Redis String (opsForValue)

kisSession (WebSocketSession): 직렬화 불가로 유일하게 volatile 인스턴스 변수(메모리)에 유지.

subTicker(...): void에서 int 반환하도록 수정. Redis SADD 후 SIZE를 조회하여 현재 구독자 수를 반환.

updateApprovalKey(...): void 메소드 구현. opsForValue().set()을 통해 Redis의 승인 키를 덮어씀.

@PostConstruct init(): updateApprovalKey를 호출하도록 수정.

5. securities/src/main/java/com/baas/securities/service/KisService.java

(핵심) subRealtimeStock(...) 메소드 삭제. (Race Condition 유발 및 StompPreHandler와 로직 중복)

subscribeToStock(String ticker): public 메소드로 변경. (KIS 구독 메시지 전송 담당)

unsubscribeFromStock(String ticker): public 메소드로 신규 추가. (KIS 구독 해지 메시지 전송 담당)

fetchNewApprovalKeyFromKisApi(): public 메소드로 신규 추가. (KisScheduler가 호출할 KIS API 호출 담당, 현재는 임시 값 반환)

6. securities/src/main/java/com/baas/securities/controller/RealTimeTradingController.java

subRealtimeStockInfo(...) (@MessageMapping("/stock/{ticker}")) 메소드 삭제 (또는 주석 처리).

이유: StompPreHandler가 모든 구독 로직을 중앙 처리하도록 변경됨에 따라, 컨트롤러의 중복 로직을 제거하여 Race Condition을 원천 차단함.

## 📎 Issue 번호
#1 
