### PR TITLE
ACC-03 계좌 관리

### DIFF
--- a/bank/src/main/java/com/baas/bank/BankApplication.java
+++ b/bank/src/main/java/com/baas/bank/BankApplication.java
@@ -6,7 +6,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@MapperScans({@MapperScan("com.baas.bank.user.mapper") // 사용자 매퍼 경로
+@MapperScans({
+    @MapperScan("com.baas.bank.user.mapper"), // 사용자 매퍼 경로
+    @MapperScan("com.baas.bank.account.mapper") // 계좌 매퍼 경로
 })
 public class BankApplication {
     public static void main(String[] args) {

--- a/bank/src/main/java/com/baas/bank/account/controller/AccountController.java
+++ b/bank/src/main/java/com/baas/bank/account/controller/AccountController.java
@@ -1,0 +1,90 @@
+package com.baas.bank.account.controller;
+
+import com.baas.bank.account.dto.*;
+import com.baas.bank.account.service.AccountService;
+import com.baas.bank.auth.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/accounts")
+@RequiredArgsConstructor
+public class AccountController {
+    
+    private final AccountService accountService;
+    
+    /**
+     * 계좌 개설
+     * POST /accounts
+     */
+    @PostMapping
+    public ResponseEntity<AccountCreateResponse> createAccount(@RequestBody AccountCreateRequest request) {
+        // Long userId = getCurrentUserId();
+        
+        // AccountCreateResponse response = accountService.createAccount(userId, request);
+        // return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        
+        // [테스트용] 로그인 없이 userId만으로 테스트하는 경우
+        if (request.getUserId() == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        AccountCreateResponse response = accountService.createAccount(request.getUserId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+    
+    /**
+     * 계좌 별칭 등록/수정
+     * PUT /accounts/{id}/alias
+     */
+    @PutMapping("/{id}/alias")
+    public ResponseEntity<String> updateAlias(
+            @PathVariable Long id,
+            @RequestBody AliasUpdateRequest request,@RequestParam Long userId) {
+        // Long userId = getCurrentUserId();
+        
+        // accountService.updateAlias(userId, id, request.getAlias());
+        // return ResponseEntity.ok("별칭이 업데이트되었습니다.");
+        
+        // [테스트용] 로그인 없이 userId만으로 테스트하는 경우
+        // @RequestParam Long userId 추가 필요
+        accountService.updateAlias(userId, id, request.getAlias());
+        return ResponseEntity.ok("별칭이 업데이트되었습니다.");
+        
+    }
+    
+    /**
+     * 계좌 목록 조회
+     * GET /accounts
+     */
+    @GetMapping
+    public ResponseEntity<AccountListResponse> getAccounts(@RequestParam Long userId) {
+        // Long userId = getCurrentUserId();
+        
+        // AccountListResponse response = accountService.getAccountsByUserId(userId);
+        // return ResponseEntity.ok(response);
+        
+        // [테스트용] 로그인 없이 userId만으로 테스트하는 경우
+        // @RequestParam Long userId 추가 필요
+        AccountListResponse response = accountService.getAccountsByUserId(userId);
+        return ResponseEntity.ok(response);
+    }
+    
+    /**
+     * 현재 로그인한 사용자의 ID를 가져옵니다.
+     */
+    private Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new RuntimeException("인증되지 않은 사용자입니다.");
+        }
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getUser().getId();
+    }
+}
+

--- a/bank/src/main/java/com/baas/bank/account/dto/AccountCreateRequest.java
+++ b/bank/src/main/java/com/baas/bank/account/dto/AccountCreateRequest.java
@@ -1,0 +1,19 @@
+package com.baas.bank.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class AccountCreateRequest {
+    // [테스트용] 로그인 없이 userId만으로 테스트하는 경우 사용
+    private Long userId;         // 사용자 ID
+    private String bankCode;     // 은행 코드
+    private String password;     // 계좌 비밀번호
+    private String alias;        // 별칭 (선택사항)
+}
+

--- a/bank/src/main/java/com/baas/bank/account/dto/AccountCreateResponse.java
+++ b/bank/src/main/java/com/baas/bank/account/dto/AccountCreateResponse.java
@@ -1,0 +1,21 @@
+package com.baas.bank.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AccountCreateResponse {
+    private Long id;
+    private String accountNumber;
+    private String bankCode;
+    private String alias;
+    private Long balance;
+    private LocalDateTime issuedAt;
+    private LocalDateTime expiredAt;
+}
+

--- a/bank/src/main/java/com/baas/bank/account/dto/AccountDto.java
+++ b/bank/src/main/java/com/baas/bank/account/dto/AccountDto.java
@@ -1,0 +1,23 @@
+package com.baas.bank.account.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class AccountDto {
+    private Long id;                    // id
+    private Long userId;                 // user_id
+    private String accountNumber;        // account_number
+    private String bankCode;             // bank_code
+    private String alias;                // alias
+    private Long balance;                // balance
+    private String password;             // password
+    private LocalDateTime lastUpdated;   // last_updated
+    private LocalDateTime issuedAt;      // issued_at
+    private LocalDateTime expiredAt;     // expired_at
+}
+

--- a/bank/src/main/java/com/baas/bank/account/dto/AccountListResponse.java
+++ b/bank/src/main/java/com/baas/bank/account/dto/AccountListResponse.java
@@ -1,0 +1,16 @@
+package com.baas.bank.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AccountListResponse {
+    private String status;           // "SUCCESS" or "NO_ACCOUNT"
+    private List<AccountResponse> accounts;
+}
+

--- a/bank/src/main/java/com/baas/bank/account/dto/AccountResponse.java
+++ b/bank/src/main/java/com/baas/bank/account/dto/AccountResponse.java
@@ -1,0 +1,21 @@
+package com.baas.bank.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AccountResponse {
+    private Long id;
+    private String accountNumber;
+    private String bankCode;
+    private String alias;
+    private Long balance;
+    private LocalDateTime issuedAt;
+    private LocalDateTime expiredAt;
+}
+

--- a/bank/src/main/java/com/baas/bank/account/dto/AliasUpdateRequest.java
+++ b/bank/src/main/java/com/baas/bank/account/dto/AliasUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.baas.bank.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class AliasUpdateRequest {
+    private String alias;
+}
+

--- a/bank/src/main/java/com/baas/bank/account/mapper/AccountMapper.java
+++ b/bank/src/main/java/com/baas/bank/account/mapper/AccountMapper.java
@@ -1,0 +1,23 @@
+package com.baas.bank.account.mapper;
+
+import com.baas.bank.account.dto.AccountDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface AccountMapper {
+    void insertAccount(AccountDto account);
+    
+    AccountDto findById(Long id);
+    
+    AccountDto findByAccountNumber(String accountNumber);
+    
+    List<AccountDto> findByUserId(Long userId);
+    
+    void updateAlias(@Param("id") Long id, @Param("alias") String alias);
+    
+    boolean existsByAccountNumber(String accountNumber);
+}
+

--- a/bank/src/main/java/com/baas/bank/account/service/AccountService.java
+++ b/bank/src/main/java/com/baas/bank/account/service/AccountService.java
@@ -1,0 +1,123 @@
+package com.baas.bank.account.service;
+
+import com.baas.bank.account.dto.*;
+import com.baas.bank.account.mapper.AccountMapper;
+import com.baas.bank.account.util.AccountNumberGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+    
+    private final AccountMapper accountMapper;
+    private final AccountNumberGenerator accountNumberGenerator;
+    private final PasswordEncoder passwordEncoder;
+    
+    private static final String DEFAULT_ALIAS = "입출금통장";
+    private static final int ACCOUNT_EXPIRY_YEARS = 5; // 계좌 만료 기간 5년
+    
+    @Transactional
+    public AccountCreateResponse createAccount(Long userId, AccountCreateRequest request) {
+        // 계좌번호 생성 (중복 체크 포함)
+        String accountNumber;
+        int maxAttempts = 10;
+        int attempts = 0;
+        
+        do {
+            accountNumber = accountNumberGenerator.generateAccountNumber();
+            attempts++;
+            if (attempts >= maxAttempts) {
+                throw new RuntimeException("계좌번호 생성에 실패했습니다. 다시 시도해주세요.");
+            }
+        } while (accountMapper.existsByAccountNumber(accountNumber));
+        
+        // 계좌 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        
+        // 별칭 설정 (없으면 기본값)
+        String alias = (request.getAlias() != null && !request.getAlias().trim().isEmpty()) 
+                ? request.getAlias().trim() 
+                : DEFAULT_ALIAS;
+        
+        // 만료일 계산 (발급일로부터 5년)
+        LocalDateTime issuedAt = LocalDateTime.now();
+        LocalDateTime expiredAt = issuedAt.plusYears(ACCOUNT_EXPIRY_YEARS);
+        
+        // AccountDto 생성
+        AccountDto account = new AccountDto();
+        account.setUserId(userId);
+        account.setAccountNumber(accountNumber);
+        account.setBankCode(request.getBankCode());
+        account.setAlias(alias);
+        account.setBalance(1000000L); // 기본 잔액 1,000,000원
+        account.setPassword(encodedPassword);
+        account.setIssuedAt(issuedAt);
+        account.setExpiredAt(expiredAt);
+        
+        // DB 저장
+        accountMapper.insertAccount(account);
+        
+        // 응답 생성
+        return new AccountCreateResponse(
+                account.getId(),
+                account.getAccountNumber(),
+                account.getBankCode(),
+                account.getAlias(),
+                account.getBalance(),
+                account.getIssuedAt(),
+                account.getExpiredAt()
+        );
+    }
+    
+    @Transactional
+    public void updateAlias(Long userId, Long accountId, String alias) {
+        // 계좌 존재 및 소유권 확인
+        AccountDto account = accountMapper.findById(accountId);
+        if (account == null) {
+            throw new RuntimeException("계좌를 찾을 수 없습니다.");
+        }
+        
+        if (!account.getUserId().equals(userId)) {
+            throw new RuntimeException("해당 계좌에 대한 권한이 없습니다.");
+        }
+        
+        // 별칭 업데이트
+        String updatedAlias = (alias != null && !alias.trim().isEmpty()) 
+                ? alias.trim() 
+                : DEFAULT_ALIAS;
+        
+        accountMapper.updateAlias(accountId, updatedAlias);
+    }
+    
+    public AccountListResponse getAccountsByUserId(Long userId) {
+        List<AccountDto> accounts = accountMapper.findByUserId(userId);
+        
+        if (accounts.isEmpty()) {
+            return new AccountListResponse("NO_ACCOUNT", null);
+        }
+        
+        List<AccountResponse> accountResponses = accounts.stream()
+                .map(account -> new AccountResponse(
+                        account.getId(),
+                        account.getAccountNumber(),
+                        account.getBankCode(),
+                        account.getAlias(),
+                        account.getBalance(),
+                        account.getIssuedAt(),
+                        account.getExpiredAt()
+                ))
+                .collect(Collectors.toList());
+        
+        return new AccountListResponse("SUCCESS", accountResponses);
+    }
+}
+

--- a/bank/src/main/java/com/baas/bank/account/util/AccountNumberGenerator.java
+++ b/bank/src/main/java/com/baas/bank/account/util/AccountNumberGenerator.java
@@ -1,0 +1,28 @@
+package com.baas.bank.account.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+public class AccountNumberGenerator {
+    
+    private static final Random RANDOM = new Random();
+    private static final String DIGITS = "0123456789";
+    
+    /**
+     * 계좌번호를 생성합니다.
+     * 형식: 12자리 숫자 (예: 123456789012)
+     * 
+     * @return 생성된 계좌번호
+     */
+    public String generateAccountNumber() {
+        StringBuilder accountNumber = new StringBuilder();
+        for (int i = 0; i < 12; i++) {
+            int index = RANDOM.nextInt(DIGITS.length());
+            accountNumber.append(DIGITS.charAt(index));
+        }
+        return accountNumber.toString();
+    }
+}
+

--- a/bank/src/main/resources/application.properties
+++ b/bank/src/main/resources/application.properties
@@ -13,7 +13,7 @@ spring.datasource.password=${DB_PASSWORD}
 mybatis.configuration.map-underscore-to-camel-case=true
 # Mapper ??
 mybatis.mapper-locations=classpath:mapper/*.xml
-mybatis.type-aliases-package=com.baas.bank.user.dto,com.baas.bank.oauth2.dto
+mybatis.type-aliases-package=com.baas.bank.user.dto,com.baas.bank.oauth2.dto,com.baas.bank.account.dto
 
 #Redis
 spring.data.redis.host:${REDIS_HOST}

--- a/bank/src/main/resources/mapper/AccountMapper.xml
+++ b/bank/src/main/resources/mapper/AccountMapper.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.baas.bank.account.mapper.AccountMapper">
+
+    <insert id="insertAccount" parameterType="AccountDto" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO account (user_id, account_number, bank_code, alias, balance, password, issued_at, expired_at)
+        VALUES (#{userId}, #{accountNumber}, #{bankCode}, #{alias}, #{balance}, #{password}, #{issuedAt}, #{expiredAt})
+    </insert>
+
+    <select id="findById" parameterType="Long" resultType="AccountDto">
+        SELECT id, user_id, account_number, bank_code, alias, balance, password,
+               last_updated, issued_at, expired_at
+        FROM account
+        WHERE id = #{id}
+    </select>
+
+    <select id="findByAccountNumber" parameterType="String" resultType="AccountDto">
+        SELECT id, user_id, account_number, bank_code, alias, balance, password,
+               last_updated, issued_at, expired_at
+        FROM account
+        WHERE account_number = #{accountNumber}
+    </select>
+
+    <select id="findByUserId" parameterType="Long" resultType="AccountDto">
+        SELECT id, user_id, account_number, bank_code, alias, balance, password,
+               last_updated, issued_at, expired_at
+        FROM account
+        WHERE user_id = #{userId}
+        ORDER BY issued_at DESC
+    </select>
+
+    <update id="updateAlias">
+        UPDATE account
+        SET alias = #{alias}
+        WHERE id = #{id}
+    </update>
+
+    <select id="existsByAccountNumber" parameterType="String" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM account
+        WHERE account_number = #{accountNumber}
+    </select>
+
+</mapper>
+


### PR DESCRIPTION
## 📄 PR 한 줄 요약
계좌 개설, 조회, 별칭 수정 api 구현

## 🧑‍💻 PR 세부 내용
- 계좌 개설 (POST /accounts)**: 랜덤 12자리 계좌번호 생성, 비밀번호 암호화, 만료일 자동 설정(5년), 기본 잔액 1,000,000원
- 계좌 별칭 수정 (PUT /accounts/{id}/alias)**: 별칭 미지정 시 기본값 "입출금통장" 자동 설정, 계좌 소유권 검증
- 계좌 목록 조회 (GET /accounts)**: 사용자별 계좌 목록 조회, 계좌 없을 경우 "NO_ACCOUNT" 상태 반환
- **도메인 구조**: AccountDto, AccountMapper, AccountService, AccountController 구현, AccountNumberGenerator 유틸리티 추가
- **설정 변경**: BankApplication에 AccountMapper 스캔 추가, application.properties에 AccountDto 타입 별칭 추가



## 📎 Issue 번호
#17 #18 #20 
<!-- closed #번호 -->
